### PR TITLE
Change to inspector responsibilities (GIS data). Tests updated to match.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To get a snapshot of the production database for use locally, use Heroku's `pg:p
 At time of writing, the following commands worked:
 ```bash
 $ dropdb inspector_gadget_development
-$ heroku pg:pull DATABASE_URL inspector_gadget_development
+$ heroku pg:pull DATABASE_URL inspector_gadget_development --app inspector-gadget-cfa
 ```
 
 ## Updating Inspector Regions


### PR DESCRIPTION
Addresses #91

The key assignment change here (aside from updating the GIS data, not stored in this repo) is that Aaker gets `building` inspections in `inspectors.rb`.

The rest of the changes are new geocoder stubs and related tests to make sure that inspections in the north, mid-city, and south regions assign correctly. One test for each region.

@lxchavez
